### PR TITLE
Translation of xids from and to the controller and switches have been fi...

### DIFF
--- a/RELEASE-NOTES
+++ b/RELEASE-NOTES
@@ -1,3 +1,6 @@
+FlowVisor 1.0.10 : July 1 2013
+    * FLOWVISOR-244-extension : Fixed an issue with the translation and untranslation of xids with the controller and switches.
+
 FlowVisor 1.0.9 : June 25 2013
     * FLOWVISOR-244 : Flow stats reply sent by FlowVisor doesn't set the "more replies" flag
 

--- a/src/org/flowvisor/FlowVisor.java
+++ b/src/org/flowvisor/FlowVisor.java
@@ -40,7 +40,7 @@ public class FlowVisor {
 	public final static int FLOWVISOR_VENDOR_EXTENSION = 0x80000001;
 
 	// VERSION
-	public final static String FLOWVISOR_VERSION = "flowvisor-1.0.9";
+	public final static String FLOWVISOR_VERSION = "flowvisor-1.0.10";
 	public final static int FLOWVISOR_DB_VERSION = 2;
 
 

--- a/src/org/flowvisor/classifier/FVClassifier.java
+++ b/src/org/flowvisor/classifier/FVClassifier.java
@@ -1074,6 +1074,7 @@ public class FVClassifier implements FVEventHandler, FVSendMsg, FlowMapChangedLi
 		}
 		statsReply.setStatistics(stats);
 		statsReply.setFlags(flag);	
+		FVLog.log(LogLevel.DEBUG, null, "xid is: ", original.getXid());
 		statsReply.setXid(original.getXid());
 		
 		statsReply.setVersion(original.getVersion());
@@ -1097,6 +1098,7 @@ public class FVClassifier implements FVEventHandler, FVSendMsg, FlowMapChangedLi
 				FVLog.log(LogLevel.WARN, this, "Unable to classify stats - ignoring - ", stat);
 				continue;
 			}
+			//FVLog.log(LogLevel.DEBUG, this, " stat.getCookie: ",stat.getCookie(), " pair.getCookie: ", pair.getCookie());
 			stat.setTransCookie(stat.getCookie());
 			stat.setCookie(pair.getCookie());
 			addToFlowStats(stat, pair.getSliceName());
@@ -1138,6 +1140,7 @@ public class FVClassifier implements FVEventHandler, FVSendMsg, FlowMapChangedLi
 		stats.add(statsReq);
 		request.setStatistics(stats);
 		request.setLengthU(FVStatisticsRequest.MINIMUM_LENGTH + statsReq.computeLength());
+		FVLog.log(LogLevel.DEBUG, null, "orig.getXid() inside pollFlowTableStats: ", orig.getXid());
 		request.setXid(orig == null ? -1 : orig.getXid());
 		this.sendMsg(request, this);
 		

--- a/src/org/flowvisor/message/FVMessageUtil.java
+++ b/src/org/flowvisor/message/FVMessageUtil.java
@@ -56,6 +56,8 @@ public class FVMessageUtil {
 			FVClassifier fvClassifier, FVSlicer fvSlicer) {
 		XidTranslatorWithMessage xidTranslator = (XidTranslatorWithMessage) fvClassifier.getXidTranslator();
 		int newXid = xidTranslator.translate(msg.clone(), msg.getXid(), fvSlicer);
+		FVLog.log(LogLevel.DEBUG,null,"Inside translateXidMsg - msg.getXid() is: ", msg.getXid(),
+				" newXid is: ",newXid);
 		msg.setXid(newXid);
 	}
 
@@ -73,6 +75,8 @@ public class FVMessageUtil {
 		XidPair pair = xidTranslator.untranslate(msg.getXid());
 		if (pair == null)
 			return null;
+		FVLog.log(LogLevel.DEBUG,null,"Inside untranslateXid - msg.getXid() is: ", msg.getXid(),
+				" pair.getXid() is: ",pair.getXid());
 		msg.setXid(pair.getXid());
 		String sliceName = pair.getSliceName();
 		return fvClassifier.getSlicerByName(sliceName);

--- a/src/org/flowvisor/message/statistics/FVFlowStatisticsRequest.java
+++ b/src/org/flowvisor/message/statistics/FVFlowStatisticsRequest.java
@@ -1,13 +1,16 @@
 package org.flowvisor.message.statistics;
 
 import org.flowvisor.classifier.FVClassifier;
+import org.flowvisor.classifier.XidPairWithMessage;
 import org.flowvisor.log.FVLog;
 import org.flowvisor.log.LogLevel;
 import org.flowvisor.message.FVMessageUtil;
 import org.flowvisor.message.FVStatisticsReply;
 import org.flowvisor.message.FVStatisticsRequest;
 import org.flowvisor.slicer.FVSlicer;
+import org.openflow.protocol.OFStatisticsReply.OFStatisticsReplyFlags;
 import org.openflow.protocol.statistics.OFFlowStatisticsRequest;
+import org.openflow.protocol.statistics.OFStatisticsType;
 
 public final class FVFlowStatisticsRequest extends OFFlowStatisticsRequest
 		implements SlicableStatistic, ClassifiableStatistic {
@@ -25,9 +28,19 @@ public final class FVFlowStatisticsRequest extends OFFlowStatisticsRequest
 	public void sliceFromController(FVStatisticsRequest msg, FVClassifier fvClassifier,
 			FVSlicer fvSlicer) {
 		FVMessageUtil.translateXidMsg(msg,fvClassifier, fvSlicer);
-		if (!fvClassifier.pollFlowTableStats(msg))
-			fvClassifier.sendFlowStatsResp(fvSlicer, msg, (short)0);
 		
+		if (!fvClassifier.pollFlowTableStats(msg)){
+			XidPairWithMessage pair = FVMessageUtil
+					.untranslateXidMsg(msg, fvClassifier);
+			if (pair == null) {
+				FVLog.log(LogLevel.WARN, fvClassifier,
+						"dropping unclassifiable stats reply: ", this);
+				return;
+			}
+			FVStatisticsRequest original = (FVStatisticsRequest) pair.getOFMessage();
+			
+			fvClassifier.sendFlowStatsResp(pair.getSlicer(), original, msg.getFlags());
+		}
 	}
 	
 	


### PR DESCRIPTION
...xed. The problem was that when a xid comes from the controller FV translates it to a new xid and sends it to the switch and untranslates the xid back to the original xid once the response from the switch is received. But if the request is never sent to the switch and for any request from the controller if FV can answer just from its cache, then though a translation of xid was done initially when the request was received from the controller. The untranslation was never done before sending the cached information as the response to the controller.
