### PR TITLE
The statsReply segment was getting cut because the range of signed short...

### DIFF
--- a/src/org/flowvisor/FlowVisor.java
+++ b/src/org/flowvisor/FlowVisor.java
@@ -40,7 +40,7 @@ public class FlowVisor {
 	public final static int FLOWVISOR_VENDOR_EXTENSION = 0x80000001;
 
 	// VERSION
-	public final static String FLOWVISOR_VERSION = "flowvisor-1.0.10";
+	public final static String FLOWVISOR_VERSION = "flowvisor-1.0.11-RC2";
 	public final static int FLOWVISOR_DB_VERSION = 2;
 
 

--- a/src/org/flowvisor/classifier/FVClassifier.java
+++ b/src/org/flowvisor/classifier/FVClassifier.java
@@ -1078,13 +1078,12 @@ public class FVClassifier implements FVEventHandler, FVSendMsg, FlowMapChangedLi
 				if (new FVMatch(orig.getMatch()).subsumes(new FVMatch(reply.getMatch()))) {
 					if (orig.getOutPort() == OFPort.OFPP_NONE.getValue() ||
 							matchContainsPort(reply, orig.getOutPort())) {	 
-						FVLog.log(LogLevel.DEBUG, classifier, "Appending FlowStats reply: ", reply);
 						//Add to statsReply only if the total length is less than 88*700 = 61600B
 						//slightly less than 64kB and a multiplier of 88 which is the size of the struct
 						//ofp_flow_stats_reply according to the OF1.0 spec
-						FVLog.log(LogLevel.DEBUG, null, "statsReply.getLength() + reply.computeLength(): ", (statsReply.getLength() + reply.computeLength()));
-						if ((statsReply.getLength() + reply.computeLength())<(88*700) ){
-							statsReply.setLengthU(statsReply.getLength() + reply.computeLength());
+						FVLog.log(LogLevel.DEBUG, null, "statsReply.getLengthU() & reply.computeLength(): ", statsReply.getLengthU(), " ", reply.computeLength());
+						if ((statsReply.getLengthU() + reply.computeLength())<(44*700) ){
+							statsReply.setLengthU(statsReply.getLengthU() + reply.computeLength());
 							stats.add(reply);
 						}
 						else{
@@ -1115,13 +1114,13 @@ public class FVClassifier implements FVEventHandler, FVSendMsg, FlowMapChangedLi
 			//If it is the last segment of the statsReply msg, send it!
 			statsReply.setStatistics(stats);
 			statsReply.setFlags((short)0);	
-			FVLog.log(LogLevel.DEBUG, null, "xid is: ", original.getXid());
+			FVLog.log(LogLevel.DEBUG, null, "xid is: ", original.getXid(), "STATS REPLY FLAG: ", statsReply.getFlags());
 			statsReply.setXid(original.getXid());
 		
 			statsReply.setVersion(original.getVersion());
 			statsReply.setStatisticType(original.getStatisticType());
 		
-			FVLog.log(LogLevel.DEBUG, null, "STATS_REPLY SIZE1: ", statsReply.getStatistics().size(),"Stats Reply Length1: ", statsReply.getLengthU());
+			FVLog.log(LogLevel.DEBUG, null, "END STATS_REPLY SIZE: ", statsReply.getStatistics().size(),"End Stats Reply Length: ", statsReply.getLengthU());
 		
 			if (statsReply.getStatistics().size() == 0) 
 				FVLog.log(LogLevel.WARN, fvSlicer, "Stats request resulted in an empty set ", original);

--- a/src/org/flowvisor/classifier/FVClassifier.java
+++ b/src/org/flowvisor/classifier/FVClassifier.java
@@ -119,10 +119,6 @@ public class FVClassifier implements FVEventHandler, FVSendMsg, FlowMapChangedLi
 	private boolean wantStatsDescHack;
 	String floodPermsSlice; // the slice that has permission to use native
 	private Boolean flowTracking = false;
-	public static final int STATS_SEG_SIZE = 30800; // (44*700=30800), a multiplier of 44 which is half of 88,
-													// which is the size of the struct
-													// ofp_flow_stats_reply according to the OF1.0 spec
-
 	
 	private HashMap<String, Integer> fmlimits = new HashMap<String, Integer>();
 	private HashMap<String, Integer> currfmlimits = new HashMap<String, Integer>();
@@ -1075,6 +1071,9 @@ public class FVClassifier implements FVEventHandler, FVSendMsg, FlowMapChangedLi
 			FVFlowStatisticsRequest orig = (FVFlowStatisticsRequest) original.getStatistics().get(0);
 			List<OFStatistics> stats = new LinkedList<OFStatistics>();
 			FVStatisticsReply statsReply = new FVStatisticsReply();
+			final int STATS_SEG_SIZE = 30800; // (44*700=30800), a multiplier of 44 which is half of 88,
+											  // which is the size of the struct
+								   			  // ofp_flow_stats_reply according to the OF1.0 spec
 			statsReply.setLengthU(FVStatisticsReply.MINIMUM_LENGTH);
 
 			for (FVFlowStatisticsReply reply : replies) {
@@ -1083,7 +1082,7 @@ public class FVClassifier implements FVEventHandler, FVSendMsg, FlowMapChangedLi
 							matchContainsPort(reply, orig.getOutPort())) {	 
 						//Add to statsReply only if the total length is less than 44*700 = 30800B
 						//slightly less than half of 64kB 
-						if ((statsReply.getLengthU() + reply.computeLength())<(44*700) ){
+						if ((statsReply.getLengthU() + reply.computeLength())<STATS_SEG_SIZE){
 							statsReply.setLengthU(statsReply.getLengthU() + reply.computeLength());
 							stats.add(reply);
 						}


### PR DESCRIPTION
...s is till 32767, and we had assigned each segment of the statsReply to 61600 Bytes. Changed the setting and getting of length of the StatsReply from signed short to unsigned short and the range of each segment of StatsReply to 30800.
