### PR TITLE
Fixed Double to Long cast bug for nw_dst when reading config

### DIFF
--- a/src/org/flowvisor/config/FlowSpaceImpl.java
+++ b/src/org/flowvisor/config/FlowSpaceImpl.java
@@ -862,7 +862,7 @@ public class FlowSpaceImpl implements FlowSpace {
 			if (row.get(NWDST) == null) 
 				ps.setNull(10, Types.INTEGER);
 			else
-				ps.setInt(10, ((Long) row.get(NWDST)).intValue());
+				ps.setInt(10, ((Double) row.get(NWDST)).intValue());
 			if (row.get(NWPROTO) == null) 
 				ps.setNull(11, Types.SMALLINT);
 			else


### PR DESCRIPTION
On startup, when parsing the JSON config file where the field nw_dst is present for a flowspace rule, an exception occurs that Double can't be cast to Long.
This is due to GSON parsing every number as Double and FlowSpaceImpl expecting a Long (which it could be if GSON wouldn't parse it as Double...) after taking the argument out of the HashMap. The casts of all the other values are already Double casts, so I guess someone simply forgot to change it.
