### PR TITLE
Escapes FV_JVM_ARGS in flowvisor.sh

### DIFF
--- a/scripts/flowvisor.sh
+++ b/scripts/flowvisor.sh
@@ -8,7 +8,7 @@ if [ -z "$FV_RUN_AS_ROOT" -o "x$FV_RUN_AS_ROOT" != "xyes" ]; then
         exit 1
     fi
 fi
- 
+
 
 if [ -z $base ] ; then
     envs=`dirname $0`/../scripts/envs.sh
@@ -27,16 +27,16 @@ fi
 default_jvm_args="-server -Xms100M -Xmx2000M -XX:OnError=flowvisor-crash-logger -XX:+UseConcMarkSweepGC $fv_defines"
 
 
-if [ -z $FV_JVM_ARGS ]; then
+if [ -z "$FV_JVM_ARGS" ]; then
     export FV_JVM_ARGS="$default_jvm_args"
 fi
 
 if [ ! -z $FV_DEBUG_PORT ] ; then
-# Checkout http://java.dzone.com/articles/how-debug-remote-java-applicat for 
+# Checkout http://java.dzone.com/articles/how-debug-remote-java-applicat for
 # remote debugging details in java
     FV_JVM_ARGS="$FV_JVM_ARGS -Xdebug -Xrunjdwp:transport=dt_socket,suspend=n,address=$FV_DEBUG_PORT,server=y"
 fi
 
-echo Starting FlowVisor >&2 
+echo Starting FlowVisor >&2
 #echo Running with FV_JVM_ARGS=$FV_JVM_ARGS >&2
-exec java $FV_JVM_ARGS $fv_defines $sslopts -cp $classpath org.flowvisor.FlowVisor "$@" 
+exec java $FV_JVM_ARGS $fv_defines $sslopts -cp $classpath org.flowvisor.FlowVisor "$@"


### PR DESCRIPTION
Since it is used in a '-z' shell's test, FV_JVM_ARGS needs to be escaped. Otherwise, if you try to pass many options, "-server -Xmx2G", for example, bash will return "[: too many arguments".
